### PR TITLE
Correct indices in meshKronPoly.m

### DIFF
--- a/src/meshKronPoly.m
+++ b/src/meshKronPoly.m
@@ -27,8 +27,8 @@ function [figID] = meshKronPoly(v,x1,x2,titleStr,filename)
 
   eFcn = zeros(n1,n2);
   [X,Y] = meshgrid(x1,x2);
-  for i=1:n1
-    for j=1:n2
+  for i=1:n2 % See documentation for meshgrid
+    for j=1:n1 % See documentation for meshgrid
       x = [X(i,j);Y(i,j)];
       eFcn(i,j) = kronPolyEval(v,x,degree);
     end


### PR DESCRIPTION
According to the documentation for meshgrid():
"[X,Y] = meshgrid(x,y) returns 2-D grid coordinates based on the coordinates contained in vectors x and y. X is a matrix where each row is a copy of x, and Y is a matrix where each column is a copy of y. The grid represented by the coordinates X and Y has length(y) rows and length(x) columns."

In lines 30 and 31, the indices needed to be flipped so i=1:n2 and j=1:n1. This is because X and Y are both n2 by n1 matrices due to meshgrid().